### PR TITLE
Fix license spelling error

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "esmangle"
   ],
   "homepage": "https://github.com/zertosh/esmangle-evaluator",
-  "licence": "MIT",
+  "license": "MIT",
   "author": "Andres Suarez <zertosh@gmail.com>",
   "main": "evaluator.js",
   "repository": {


### PR DESCRIPTION
Both spellings are correct, but npm specifies this one, which tools like `legal-eagle` look for (see https://docs.npmjs.com/files/package.json#license)
